### PR TITLE
Make broken_circuit_complex return immutable SimplicialComplex

### DIFF
--- a/src/sage/matroids/circuits_matroid.pyx
+++ b/src/sage/matroids/circuits_matroid.pyx
@@ -829,7 +829,7 @@ cdef class CircuitsMatroid(Matroid):
         from sage.topology.simplicial_complex import SimplicialComplex
         if self.loops():
             raise ValueError("broken circuit complex of matroid with loops is not defined")
-        return SimplicialComplex(self.no_broken_circuits_facets(ordering, reduced), maximality_check=False)
+        return SimplicialComplex(self.no_broken_circuits_facets(ordering, reduced), maximality_check=False, is_immutable=True)
 
     # properties
 

--- a/src/sage/matroids/circuits_matroid.pyx
+++ b/src/sage/matroids/circuits_matroid.pyx
@@ -829,7 +829,11 @@ cdef class CircuitsMatroid(Matroid):
         from sage.topology.simplicial_complex import SimplicialComplex
         if self.loops():
             raise ValueError("broken circuit complex of matroid with loops is not defined")
-        return SimplicialComplex(self.no_broken_circuits_facets(ordering, reduced), maximality_check=False, is_immutable=True)
+        return SimplicialComplex(
+            self.no_broken_circuits_facets(ordering, reduced),
+            maximality_check=False,
+            is_immutable=True,
+        )
 
     # properties
 

--- a/src/sage/matroids/circuits_matroid.pyx
+++ b/src/sage/matroids/circuits_matroid.pyx
@@ -825,6 +825,12 @@ cdef class CircuitsMatroid(Matroid):
             Traceback (most recent call last):
             ...
             ValueError: broken circuit complex of matroid with loops is not defined
+
+        TESTS::
+
+            sage: M = Matroid(circuits=[[1,2,3], [3,4,5], [1,2,4,5]])
+            sage: M.broken_circuit_complex().is_immutable()                             # needs sage.graphs
+            True
         """
         from sage.topology.simplicial_complex import SimplicialComplex
         if self.loops():

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -8305,7 +8305,7 @@ cdef class Matroid(SageObject):
 
         TESTS::
 
-            sage: M = Matroid(circuits=[[1,2,3], [3,4,5], [1,2,4,5]])
+            sage: M = matroids.catalog.Fano()
             sage: M.broken_circuit_complex().is_immutable()                             # needs sage.graphs
             True
 

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -8305,6 +8305,10 @@ cdef class Matroid(SageObject):
 
         TESTS::
 
+            sage: M = Matroid(circuits=[[1,2,3], [3,4,5], [1,2,4,5]])
+            sage: M.broken_circuit_complex().is_immutable()                             # needs sage.graphs
+            True
+
             sage: for M in matroids.AllMatroids(5):  # optional - matroid_database
             ....:     r = M.rank()
             ....:     if r > 0 and not M.dual().loops():

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -8323,7 +8323,7 @@ cdef class Matroid(SageObject):
         for S in self.no_broken_circuits_sets_iterator(ordering):
             if len(S) == r:
                 facets.append(S)
-        return SimplicialComplex(facets, maximality_check=False)
+        return SimplicialComplex(facets, maximality_check=False, is_immutable=True)
 
     cpdef automorphism_group(self):
         r"""


### PR DESCRIPTION


<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

Fixes #1.
The returned SimplicialComplex was mutable, causing a ValueError when attempting to hash it (e.g., adding to a set). Fixed by passing is_immutable=True to the SimplicialComplex constructor.
