### PR TITLE
Upload documentation tarballs to GitHub releases

### DIFF
--- a/.github/workflows/doc-build-livedoc.yml
+++ b/.github/workflows/doc-build-livedoc.yml
@@ -12,6 +12,9 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+.rc[0-9]+'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 env:
   PYTHON_VERSION: 3.12
 
@@ -81,14 +84,28 @@ jobs:
       - name: Copy doc
         id: copy
         run: |
+          VERSION="${{ github.ref_name }}"
           mkdir -p ./doc
           cp -r builddir/src/doc/pdf doc/
           cp -rL builddir/src/doc/html doc/
           cp builddir/src/doc/index.html doc/
           zip -r livedoc.zip doc
 
+          # Create release tarballs
+          tar -czf sage-doc-html-${VERSION}.tar.gz -C doc html
+          tar -czf sage-doc-pdf-${VERSION}.tar.gz -C doc pdf
+
       - name: Upload livedoc
         uses: actions/upload-artifact@v4
         with:
           name: livedoc
           path: livedoc.zip
+
+      - name: Upload docs to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            sage-doc-html-${{ github.ref_name }}.tar.gz
+            sage-doc-pdf-${{ github.ref_name }}.tar.gz
+          token: ${{ secrets.RELEASE_CREATION_TOKEN }}
+        if: github.ref_type == 'tag'

--- a/.github/workflows/doc-build-livedoc.yml
+++ b/.github/workflows/doc-build-livedoc.yml
@@ -84,16 +84,11 @@ jobs:
       - name: Copy doc
         id: copy
         run: |
-          VERSION="${{ github.ref_name }}"
           mkdir -p ./doc
           cp -r builddir/src/doc/pdf doc/
           cp -rL builddir/src/doc/html doc/
           cp builddir/src/doc/index.html doc/
           zip -r livedoc.zip doc
-
-          # Create release tarballs
-          tar -czf sage-doc-html-${VERSION}.tar.gz -C doc html
-          tar -czf sage-doc-pdf-${VERSION}.tar.gz -C doc pdf
 
       - name: Upload livedoc
         uses: actions/upload-artifact@v4
@@ -104,8 +99,6 @@ jobs:
       - name: Upload docs to release
         uses: softprops/action-gh-release@v2
         with:
-          files: |
-            sage-doc-html-${{ github.ref_name }}.tar.gz
-            sage-doc-pdf-${{ github.ref_name }}.tar.gz
+          files: livedoc.zip
           token: ${{ secrets.RELEASE_CREATION_TOKEN }}
         if: github.ref_type == 'tag'


### PR DESCRIPTION


<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

Fixed #3.

Add pre-built HTML and PDF documentation uploads to the release workflow. When triggered by a tag push, the workflow now creates and uploads sage-doc-html-{version}.tar.gz and sage-doc-pdf-{version}.tar.gz to the corresponding GitHub release.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


