### PR TITLE
matroids: make flats not require an argument

### DIFF
--- a/src/sage/matroids/basis_exchange_matroid.pyx
+++ b/src/sage/matroids/basis_exchange_matroid.pyx
@@ -1257,7 +1257,7 @@ cdef class BasisExchangeMatroid(Matroid):
 
     cpdef SetSystem flats(self, long k=-1):
         """
-        Return the collection of flats of the matroid of specified rank.
+        Return the collection of flats of the matroid.
 
         A *flat* is a closed set.
 

--- a/src/sage/matroids/basis_exchange_matroid.pyx
+++ b/src/sage/matroids/basis_exchange_matroid.pyx
@@ -1263,7 +1263,8 @@ cdef class BasisExchangeMatroid(Matroid):
 
         INPUT:
 
-        - ``k`` -- integer
+        - ``k`` -- integer (optional); if specified, return the rank-`k`
+          flats of the matroid
 
         OUTPUT: :class:`SetSystem`
 
@@ -1283,11 +1284,12 @@ cdef class BasisExchangeMatroid(Matroid):
             sage: len(M.flats(4))
             1
         """
+        cdef list F = []
         if k == -1:
-            all_subsets = []
             for i in range(self.rank() + 1):
-                all_subsets.extend(list(self.flats(i)))
-            return SetSystem(self._E, all_subsets)
+                F.extend(list(self.flats(i)))
+            return SetSystem(self._E, F)
+
         cdef bitset_t *flats
         cdef bitset_t *todo
         if k < 0 or k > self.full_rank():

--- a/src/sage/matroids/basis_exchange_matroid.pyx
+++ b/src/sage/matroids/basis_exchange_matroid.pyx
@@ -1255,7 +1255,7 @@ cdef class BasisExchangeMatroid(Matroid):
                 self._whitney_numbers2_rec(f_vec, flats, todo, e + 1, i + 1)
             e = bitset_next(todo[i], e)
 
-    cpdef SetSystem flats(self, long k):
+    cpdef SetSystem flats(self, long k=-1):
         """
         Return the collection of flats of the matroid of specified rank.
 
@@ -1283,6 +1283,11 @@ cdef class BasisExchangeMatroid(Matroid):
             sage: len(M.flats(4))
             1
         """
+        if k == -1:
+            all_subsets = []
+            for i in range(self.rank() + 1):
+                all_subsets.extend(list(self.flats(i)))
+            return SetSystem(self._E, all_subsets)
         cdef bitset_t *flats
         cdef bitset_t *todo
         if k < 0 or k > self.full_rank():

--- a/src/sage/matroids/basis_exchange_matroid.pyx
+++ b/src/sage/matroids/basis_exchange_matroid.pyx
@@ -1257,7 +1257,7 @@ cdef class BasisExchangeMatroid(Matroid):
 
     cpdef SetSystem flats(self, long k=-1):
         """
-        Return the collection of flats of the matroid.
+        Return the flats of the matroid.
 
         A *flat* is a closed set.
 

--- a/src/sage/matroids/flats_matroid.pxd
+++ b/src/sage/matroids/flats_matroid.pxd
@@ -16,7 +16,7 @@ cdef class FlatsMatroid(Matroid):
     cpdef full_rank(self)
 
     # enumeration
-    cpdef SetSystem flats(self, long k)
+    cpdef SetSystem flats(self, long k=*)
     cpdef list whitney_numbers(self)
     cpdef list whitney_numbers2(self)
 

--- a/src/sage/matroids/flats_matroid.pyx
+++ b/src/sage/matroids/flats_matroid.pyx
@@ -410,7 +410,7 @@ cdef class FlatsMatroid(Matroid):
 
     # enumeration
 
-    cpdef SetSystem flats(self, long k):
+    cpdef SetSystem flats(self, long k=-1):
         r"""
         Return the flats of the matroid of specified rank.
 
@@ -432,6 +432,11 @@ cdef class FlatsMatroid(Matroid):
              frozenset({1, 3}),
              frozenset({2, 3})]
         """
+        if k == -1:
+            all_subsets = []
+            for k in self._k_F:
+                all_subsets.extend(self._k_F[k])
+            return SetSystem(self._groundset, all_subsets)
         if k in self._k_F:
             return SetSystem(self._groundset, self._k_F[k])
         return SetSystem(self._groundset)

--- a/src/sage/matroids/flats_matroid.pyx
+++ b/src/sage/matroids/flats_matroid.pyx
@@ -412,7 +412,7 @@ cdef class FlatsMatroid(Matroid):
 
     cpdef SetSystem flats(self, long k=-1):
         r"""
-        Return the flats of the matroid of specified rank.
+        Return the flats of the matroid.
 
         INPUT:
 

--- a/src/sage/matroids/flats_matroid.pyx
+++ b/src/sage/matroids/flats_matroid.pyx
@@ -416,7 +416,8 @@ cdef class FlatsMatroid(Matroid):
 
         INPUT:
 
-        - ``k`` -- integer
+        - ``k`` -- integer (optional); if specified, return the rank-`k`
+          flats of the matroid
 
         OUTPUT: :class:`SetSystem`
 
@@ -432,14 +433,13 @@ cdef class FlatsMatroid(Matroid):
              frozenset({1, 3}),
              frozenset({2, 3})]
         """
+        cdef list F = []
         if k == -1:
-            all_subsets = []
-            for k in self._k_F:
-                all_subsets.extend(self._k_F[k])
-            return SetSystem(self._groundset, all_subsets)
+            for i in self._k_F:
+                F.extend(self._k_F[i])
         if k in self._k_F:
-            return SetSystem(self._groundset, self._k_F[k])
-        return SetSystem(self._groundset)
+            F.extend(self._k_F[k])
+        return SetSystem(self._groundset, F)
 
     def flats_iterator(self, k):
         r"""

--- a/src/sage/matroids/matroid.pxd
+++ b/src/sage/matroids/matroid.pxd
@@ -121,7 +121,7 @@ cdef class Matroid(SageObject):
     cpdef SetSystem dependent_sets(self, long k)
     cpdef list _extend_flags(self, list flags)
     cpdef list _flags(self, long k)
-    cpdef SetSystem flats(self, long k)
+    cpdef SetSystem flats(self, long k=*)
     cpdef SetSystem coflats(self, long k)
     cpdef SetSystem hyperplanes(self)
     cpdef list f_vector(self)

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -2999,7 +2999,7 @@ cdef class Matroid(SageObject):
 
     cpdef SetSystem flats(self, long k=-1):
         r"""
-        Return the collection of flats of the matroid of specified rank.
+        Return the collection of flats of the matroid.
 
         A *flat* is a closed set.
 
@@ -3023,12 +3023,12 @@ cdef class Matroid(SageObject):
             ['d', 'e', 'f']]
 
         TESTS::
+
             sage: M = matroids.catalog.Vamos()
             sage: M.flats(2)
             SetSystem of 28 sets over 8 elements
             sage: M.flats()
             SetSystem of 79 sets over 8 elements
-
         """
         cdef list F = []
         if k == -1:

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -2999,7 +2999,7 @@ cdef class Matroid(SageObject):
 
     cpdef SetSystem flats(self, long k=-1):
         r"""
-        Return the collection of flats of the matroid.
+        Return the flats of the matroid.
 
         A *flat* is a closed set.
 

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -3005,7 +3005,8 @@ cdef class Matroid(SageObject):
 
         INPUT:
 
-        - ``k`` -- integer
+        - ``k`` -- integer (optional); if specified, return the rank-`k`
+          flats of the matroid
 
         OUTPUT: :class:`SetSystem`
 
@@ -3020,13 +3021,22 @@ cdef class Matroid(SageObject):
             [['a', 'b', 'f'], ['a', 'c', 'e'], ['a', 'd', 'g'],
             ['b', 'c', 'd'], ['b', 'e', 'g'], ['c', 'f', 'g'],
             ['d', 'e', 'f']]
+
+        TESTS::
+            sage: M = matroids.catalog.Vamos()
+            sage: M.flats(2)
+            SetSystem of 28 sets over 8 elements
+            sage: M.flats()
+            SetSystem of 79 sets over 8 elements
+
         """
+        cdef list F = []
         if k == -1:
-            all_subsets = []
             for i in range(self.rank() + 1):
-                all_subsets.extend([f[0] for f in self._flags(i)])
-            return SetSystem(self.groundset(), subsets=all_subsets)
-        return SetSystem(self.groundset(), subsets=[f[0] for f in self._flags(k)])
+                F.extend([f[0] for f in self._flags(i)])
+        else:
+            F.extend([f[0] for f in self._flags(k)])
+        return SetSystem(self.groundset(), F)
 
     cpdef SetSystem coflats(self, long k):
         r"""

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -2997,7 +2997,7 @@ cdef class Matroid(SageObject):
             flags = self._extend_flags(flags)
         return flags
 
-    cpdef SetSystem flats(self, long k):
+    cpdef SetSystem flats(self, long k=-1):
         r"""
         Return the collection of flats of the matroid of specified rank.
 
@@ -3021,6 +3021,11 @@ cdef class Matroid(SageObject):
             ['b', 'c', 'd'], ['b', 'e', 'g'], ['c', 'f', 'g'],
             ['d', 'e', 'f']]
         """
+        if k == -1:
+            all_subsets = []
+            for i in range(self.rank() + 1):
+                all_subsets.extend([f[0] for f in self._flags(i)])
+            return SetSystem(self.groundset(), subsets=all_subsets)
         return SetSystem(self.groundset(), subsets=[f[0] for f in self._flags(k)])
 
     cpdef SetSystem coflats(self, long k):


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.


Fixes #2.

This patch makes the argument for flats optional. It uses a recursive approach to iterate through all ranks and form a set system. Since matroids have different classes, I managed to update all of them using similar strategies. If this is the correct approach, I will update the comments in the code regarding flats.
